### PR TITLE
Provide an easy way to create a development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 node_modules
 .DS_Store
+.idea/
+docker/html/
 yarn-error.log
 .sass-cache
 tals-site/assets/material-components-web.min.css
 tals-site/assets/material-components-web.min.js
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+LABEL maintainer="Andrej.Sajenko@gmail.com"
+
+VOLUME ["/var/moodledata"]
+EXPOSE 80 443
+
+# Let the container know that there is no tty
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD ./foreground.sh /etc/apache2/foreground.sh
+
+RUN apt-get update && \
+    apt-get -y install \
+    php7.2-curl \
+    curl git unzip apache2 php \
+    php-gd libapache2-mod-php wget \
+    php-pgsql curl libcurl4 php-curl \
+    php-xmlrpc php-intl php-mysql \
+    git-core php-xml php-mbstring \
+    php-zip php-soap cron
+
+RUN chown -R www-data:www-data /var/www/html && \
+    chmod +x /etc/apache2/foreground.sh
+
+# Enable SSL, moodle requires it
+RUN a2enmod ssl && a2ensite default-ssl  #if using proxy dont need actually secure connection
+
+# Cleanup, this is ran to reduce the resulting size of the image.
+RUN apt-get clean autoclean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/dpkg/* /var/lib/cache/* /var/lib/log/*
+
+CMD ["/etc/apache2/foreground.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+# Default Moodle Credentials
+
+- **Url: https://localhost:443/**
+- **Username:** user
+- **Password:** bitnami

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: moodle
+      POSTGRES_PASSWORD: jk3nothing
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  ws:
+    build: .
+    image: asjn/apachephp
+    volumes:
+      - ./html:/var/www/html/
+      - md_data:/var/moodledata
+    ports:
+      - 8080:80
+volumes:
+  db_data:
+    driver: local
+  md_data:
+    driver: local

--- a/docker/foreground.sh
+++ b/docker/foreground.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "placeholder" > /var/moodledata/placeholder
+chown -R www-data:www-data /var/moodledata
+chmod 777 /var/moodledata
+
+read pid cmd state ppid pgrp session tty_nr tpgid rest < /proc/self/stat
+trap "kill -TERM -$pgrp; exit" EXIT TERM KILL SIGKILL SIGTERM SIGQUIT
+
+#start up cron
+/usr/sbin/cron
+
+
+source /etc/apache2/envvars
+tail -F /var/log/apache2/* &
+exec apache2 -D FOREGROUND

--- a/docker/moodle-mariadb-compose.yml
+++ b/docker/moodle-mariadb-compose.yml
@@ -1,0 +1,32 @@
+version: '2'
+services:
+  mariadb:
+    image: 'bitnami/mariadb:latest'
+    environment:
+      - MARIADB_USER=bn_moodle
+      - MARIADB_DATABASE=bitnami_moodle
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - 'mariadb_data:/bitnami'
+  moodle:
+    image: 'bitnami/moodle:latest'
+    environment:
+      - MARIADB_HOST=mariadb
+      - MARIADB_PORT_NUMBER=3306
+      - MOODLE_DATABASE_USER=bn_moodle
+      - MOODLE_DATABASE_NAME=bitnami_moodle
+      - ALLOW_EMPTY_PASSWORD=yes
+    labels:
+      kompose.service.type: nodeport
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - 'moodle_data:/bitnami'
+    depends_on:
+      - mariadb
+volumes:
+  mariadb_data:
+    driver: local
+  moodle_data:
+    driver: local


### PR DESCRIPTION
Provide a docker file that starts all services required for a full development environment
of the Moodle plugin.

Have found a Moodle Container,
also an CAS container https://hub.docker.com/r/apereo/cas/.

Hope they can be easily connected such that a startup with the compose file will create a completely working environment.